### PR TITLE
Initialize React project structure for Module Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/READ.me
+++ b/READ.me
@@ -1,1 +1,0 @@
-Testing ChatGPOT Codex

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Module Management
+
+Estrutura inicial do projeto React para o módulo de Module Management, baseada no Storybook da Coca-Cola Femsa.
+
+## Desenvolvimento
+
+1. Instale as dependências:
+   ```bash
+   npm install
+   ```
+2. Ambiente de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+3. Build de produção:
+   ```bash
+   npm run build
+   ```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Module Management</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "module-management",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,11 @@
+import ModuleManagement from './modules/ModuleManagement';
+
+function App() {
+  return (
+    <div>
+      <ModuleManagement />
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/modules/ModuleManagement/ModuleManagement.jsx
+++ b/src/modules/ModuleManagement/ModuleManagement.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ModuleManagement() {
+  return (
+    <main>
+      <h1>Module Management</h1>
+      <p>Welcome to Module Management module.</p>
+    </main>
+  );
+}

--- a/src/modules/ModuleManagement/index.js
+++ b/src/modules/ModuleManagement/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModuleManagement';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- setup React project scaffolding with Vite configuration
- add ModuleManagement module and placeholder component
- provide README with development instructions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e914a7408323a2afbc06ca80cf55